### PR TITLE
removed edge+node from objectLabel

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "OpenCTI Threat Crawler",
   "description": "Search observables and vulnerabilities in Web content and give context",
-  "version": "1.0.2",
-  "manifest_version": 3,
+  "version": "1.0.3",
+  "manifest_version": 4,
   "action": {
     "default_popup": "index.html",
     "default_title": "Open the popup"

--- a/src/QueryHelpers.tsx
+++ b/src/QueryHelpers.tsx
@@ -21,13 +21,9 @@ export const searchIndicator = async (observable: any, storage: any) => {
               x_opencti_score
               indicator_types
               objectLabel {
-                edges {
-                  node {
                     id
                     value
                     color
-                  }
-                }
               } 
               stixCoreRelationships{
                 edges{
@@ -144,13 +140,9 @@ export const searchVulnerability = async (observable: any, storage: any) => {
               name
               id
               objectLabel {
-                edges {
-                  node {
                     id
                     value
                     color
-                  }
-                }
               } 
               stixCoreRelationships{
                 edges{


### PR DESCRIPTION
This pull request fixes the queries to OpenCTI as of 5.12.25. That resolves the `[ { "message": "Cannot query field \"edges\" on type \"Label\".", "locations": [ { "line": 22, "column": 17 } ], "extensions": { "code": "GRAPHQL_VALIDATION_FAILED" } } ]` error message.