### PR TITLE
Fix view without edges + nodes and remove edges and nodes from views (label)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "OpenCTI Threat Crawler",
   "description": "Search observables and vulnerabilities in Web content and give context",
-  "version": "1.0.2",
-  "manifest_version": 3,
+  "version": "1.0.3",
+  "manifest_version": 4,
   "action": {
     "default_popup": "index.html",
     "default_title": "Open the popup"

--- a/src/QueryHelpers.tsx
+++ b/src/QueryHelpers.tsx
@@ -21,13 +21,9 @@ export const searchIndicator = async (observable: any, storage: any) => {
               x_opencti_score
               indicator_types
               objectLabel {
-                edges {
-                  node {
                     id
                     value
                     color
-                  }
-                }
               } 
               stixCoreRelationships{
                 edges{
@@ -144,13 +140,9 @@ export const searchVulnerability = async (observable: any, storage: any) => {
               name
               id
               objectLabel {
-                edges {
-                  node {
                     id
                     value
                     color
-                  }
-                }
               } 
               stixCoreRelationships{
                 edges{

--- a/src/view/HomeView.tsx
+++ b/src/view/HomeView.tsx
@@ -148,9 +148,9 @@ function HomeView() {
                     observable['status']['code'] = "malicious";
                 }
                 observable['labels'] = [];
-                let nodeLabels = result['data']['indicators']['edges'][0]['node']['objectLabel']['edges'];
+                let nodeLabels = result['data']['indicators']['edges'][0]['node']['objectLabel'];
                 for (const label of nodeLabels) {
-                    observable['labels'].push(label['node']['value']);
+                    observable['labels'].push(label['value']);
                 }
                 observable['associations'] = [];
                 let nodeReports = result['data']['indicators']['edges'][0]['node']['reports']['edges'];


### PR DESCRIPTION
Sorry for the mess :-) after fixing the queryhelper, it broke in the HomeView. I tested now with labels in ipv4 and file entities and the labels are displayed correctly